### PR TITLE
Handle shiny tag objects with HTML dependencies.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,8 @@ Authors@R: c(
     person("JJ", "Allaire", role = "ctb"),
 	  person("Marion", "Praz", email="mnpraz@gmail.com", role = "ctb", comment = "New user interface"),
 	  person("Benoit", "Thieurmel", role = "ctb", email = "benoit.thieurmel@datastorm.fr"),
-	  person(given = "Titouan", family = "Robert", email = "titouan.robert@datastorm.fr", role = "ctb")
+	  person(given = "Titouan", family = "Robert", email = "titouan.robert@datastorm.fr", role = "ctb"),
+	  person("Duncan", "Murdoch", email = "murdoch.duncan@gmail.com", role = "ctb")
     )
 Description: Like package 'manipulate' does for static graphics, this package
     helps to easily add controls like sliders, pickers, checkboxes, etc. that 

--- a/R/combine_widgets.R
+++ b/R/combine_widgets.R
@@ -165,7 +165,11 @@ combineWidgets <- function(..., list = NULL, nrow = NULL, ncol = NULL, title = N
     else if (is.list(x))
       do.call(c, lapply(x, getDeps))
   }
-  deps <- getDeps(widgets)
+  deps <- c(getDeps(widgets),
+            getDeps(header),
+            getDeps(footer),
+            getDeps(leftCol),
+            getDeps(rightCol))
 
   res$dependencies <- deps
 

--- a/R/combine_widgets.R
+++ b/R/combine_widgets.R
@@ -152,12 +152,20 @@ combineWidgets <- function(..., list = NULL, nrow = NULL, ncol = NULL, title = N
     preRenderHook = preRenderCombinedWidgets
   )
 
-  # Add dependencies of embedded widgets
-  deps <- lapply(widgets, function(x) {
-    if (is.null(attr(x, "package"))) return(NULL)
-    append(getDependency(class(x)[1], attr(x, "package")), x$dependencies)
-  })
-  deps <- do.call(c, deps)
+  # Add dependencies of embedded widgets or shiny tags
+  # This works through the widgets recursively, in case
+  # we were passed a shiny.tag.list or other list of
+  # non-widgets.
+
+  getDeps <- function(x) {
+    if (!is.null(attr(x, "package")))
+      append(getDependency(class(x)[1], attr(x, "package")), x$dependencies)
+    else if (!is.null(attr(x, "html_dependencies")))
+      attr(x, "html_dependencies")
+    else if (is.list(x))
+      do.call(c, lapply(x, getDeps))
+  }
+  deps <- getDeps(widgets)
 
   res$dependencies <- deps
 


### PR DESCRIPTION
This is a fix for https://github.com/rte-antares-rpackage/manipulateWidget/issues/46.  The problem was that the `crosstalk::filter_slider` object was not a widget, but had HTML dependencies.