### PR TITLE
Fix for crosstalk incompatibility

### DIFF
--- a/R/combine_widgets.R
+++ b/R/combine_widgets.R
@@ -225,6 +225,9 @@ renderCombineWidgets <- function(expr, env = parent.frame(), quoted = FALSE) {
 
 # Private function used to prerender a combinedWidgets object
 preRenderCombinedWidgets <- function(x) {
+
+  hasCrosstalkInputs <- any(unlist(lapply(x$widgets, isCrosstalkInput)))
+
   widgets <- lapply(unname(x$widgets), function(w) {
     if (is.atomic(w)) return(structure(list(x = as.character(w)), class = "html"))
     if (is.null(w$preRenderHook)) {
@@ -318,7 +321,17 @@ preRenderCombinedWidgets <- function(x) {
   data <- lapply(widgets, function(w) w$x)
   widgetType <- sapply(widgets, function(w) class(w)[1])
 
-  x$x <- list(data = data, widgetType = widgetType, elementId = elementId, html = html);
+  x$x <- list(data = data, widgetType = widgetType, elementId = elementId, html = html,
+              hasCrosstalkInputs = hasCrosstalkInputs);
 
   x
+}
+
+# Check whether a widget is a crosstalk-package input, which will need special
+# initialization within combineWidgets()
+
+isCrosstalkInput <- function(w) {
+  inherits(w, "shiny.tag") &&
+    !is.null(w$attribs) &&
+    grepl("crosstalk-input", w$attribs$class)
 }

--- a/inst/htmlwidgets/combineWidgets.js
+++ b/inst/htmlwidgets/combineWidgets.js
@@ -53,6 +53,13 @@ HTMLWidgets.widget({
           }
         }
 
+        // Crosstalk inputs need special handling:  see
+        // https://github.com/ramnathv/htmlwidgets/issues/300
+
+        if (x.hasCrosstalkInputs && crosstalk && crosstalk.bind) {
+          crosstalk.bind();
+        }
+
         // Sometimes widgets are rendered before the size of all html element has
         // been computed. Adding a small delay fixes this problem.
         setTimeout(resizeAll, 5);


### PR DESCRIPTION
The `crosstalk` package creates input controls that are not htmlwidgets, and are not properly initialized when included by `combineWidgets()`.  See https://github.com/ramnathv/htmlwidgets/issues/300 for some discussion.  Here's a simple reproducible example:

```
---
output:
  html_document: 
    default
---

```{r echo = FALSE}

library(crosstalk)
library(d3scatter)
library(manipulateWidget)

sd <- SharedData$new(mtcars)

p <- d3scatter(sd, ~mpg, ~disp, ~cyl)
s <- filter_slider("slider", "mpg", sd, ~ mpg, round = TRUE )

combineWidgets(p, s, ncol = 1)
```

(Github eats the final closing marks on the chunk.)
