### PR TITLE
Switch order of arguments in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -141,7 +141,7 @@ Here comes the magic of package `manipulateWidget`! With this package, you only 
 
 ```{r eval = FALSE}
 manipulateWidget(
-  combinedPlots(Period, Country),
+  combinedPlots(Country, Period),
   Period = mwSlider(1960, 2014, c(1960, 2014)),
   Country = mwSelect(sort(unique(worldEnergyUse$country)), "United States")
 )

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ result:
 
 ``` r
 manipulateWidget(
-  combinedPlots(Period, Country),
+  combinedPlots(Country, Period),
   Period = mwSlider(1960, 2014, c(1960, 2014)),
   Country = mwSelect(sort(unique(worldEnergyUse$country)), "United States")
 )


### PR DESCRIPTION
I couldn't run the final example in the README because the arguments were swapped. I made a small fix and now it runs as expected.